### PR TITLE
Add GitHub Action to build on approved PRs

### DIFF
--- a/.github/workflows/build_on_pr_approval.yml
+++ b/.github/workflows/build_on_pr_approval.yml
@@ -1,0 +1,19 @@
+name: Build on PR Approval
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  build:
+    if: github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: mv .next/standalone/app.zip ./app.zip


### PR DESCRIPTION
## Summary
- run build when a PR to `main` gets approved

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c90f48740832d85878048fb565b60